### PR TITLE
Update server-start Hunchentoot API

### DIFF
--- a/web_with_persistent_backend.lisp
+++ b/web_with_persistent_backend.lisp
@@ -112,7 +112,7 @@
 ;; Web Server - Hunchentoot
 
 (defun start-server (port)
-  (start (make-instance 'easy-acceptor :port port)))
+  (hunchentoot:start (make-instance 'hunchentoot:easy-acceptor :port port)))
 
 (defun publish-static-content ()
   (push (create-static-file-dispatcher-and-handler

--- a/web_with_proto_backend.lisp
+++ b/web_with_proto_backend.lisp
@@ -66,7 +66,7 @@
 ;; Web Server - Hunchentoot
 
 (defun start-server (port)
-  (start (make-instance 'easy-acceptor :port port)))
+  (hunchentoot:start (make-instance 'hunchentoot:easy-acceptor :port port)))
 
 (defun publish-static-content ()
   (push (create-static-file-dispatcher-and-handler


### PR DESCRIPTION
Perhaps the Hunchentoot API has changed slightly since Lisp for the Web
was written. I had to use the API in the current Hunchentoot docs to
get the server started (using SBCL 1.2.11). This PR reflects that
change.
